### PR TITLE
Change instructions about ConversionsApi::setUserData in the readMe to use a middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ composer require esign/laravel-conversions-api
 ```
 
 Next up, you can publish the configuration file:
+
 ```bash
 php artisan vendor:publish --provider="Esign\ConversionsApi\ConversionsApiServiceProvider" --tag="config"
 ```
 
 The config file will be published as config/conversions-api.php with the following content:
+
 ```php
 return [
     /**
@@ -50,8 +52,10 @@ return [
 ## Conversions API
 
 ### Events
+
 To add events to the conversions API you may use the `addEvent`, `addEvents` or `setEvents` methods.
 Retrieving or clearing events may be done using the `getEvents` and `clearEvents` methods:
+
 ```php
 use Esign\ConversionsApi\Facades\ConversionsApi;
 use FacebookAds\Object\ServerSide\UserData;
@@ -72,6 +76,7 @@ ConversionsApi::clearEvents();
 
 Adding events won't cause them to be sent to the Conversions API.
 To actually send the events you must call the `sendEvents` method:
+
 ```php
 use Esign\ConversionsApi\Facades\ConversionsApi;
 
@@ -79,6 +84,7 @@ ConversionsApi::sendEvents();
 ```
 
 #### Creating event classes
+
 To make things a bit cleaner you may extend Facebook's default event class:
 
 ```php
@@ -100,6 +106,7 @@ class PurchaseEvent extends Event
     }
 }
 ```
+
 ```php
 ConversionsApi::addEvent(
     PurchaseEvent::create()
@@ -107,19 +114,36 @@ ConversionsApi::addEvent(
 ```
 
 ### User Data
+
 This package also comes with a way to define default user data for the user of the current request.
-You may do so by calling the `setUserData` method, this is typically done in your `AppServiceProvider`:
+You may do so by calling the `setUserData` method.
+You can set the user data for every incoming request by creating a custom middleware like this one:
+
 ```php
+namespace App\Http\Middleware;
+
 use Esign\ConversionsApi\Facades\ConversionsApi;
 use Esign\ConversionsApi\Objects\DefaultUserData;
 
-ConversionsApi::setUserData(
-    DefaultUserData::create()
-        ->setEmail(auth()->user()?->email)
-);
+class InitializeFacebookUserData
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        ConversionsApi::setUserData(
+            DefaultUserData::create()
+                ->setEmail($request->user()?->email)
+        );
+
+        return $next($request);
+    }
+}
+
 ```
 
+You can now use it in `App\Http\Kernel` as a global middleware or a route middleware.
+
 You may now pass the user data along with your events:
+
 ```php
 use Esign\ConversionsApi\Facades\ConversionsApi;
 use FacebookAds\Object\ServerSide\Event;
@@ -130,41 +154,64 @@ ConversionsApi::addEvent(
 ```
 
 ## Event deduplication
+
 This package comes with a few ways to assist you in [deduplicating browser and server events](https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events/). This can either be done using the Facebook Pixel directly or through Google Tag Manager's data layer.
 
 ### Facebook Pixel
+
 Before attempting to send events through Facebook Pixel make sure to load the pixel script:
+
 ```blade
 <x-conversions-api-facebook-pixel-script />
 ```
 
 This will render the following html:
+
 ```html
 <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-    document,'script','https://connect.facebook.net/en_US/fbevents.js');
+  !(function (f, b, e, v, n, t, s) {
+    if (f.fbq) return;
+    n = f.fbq = function () {
+      n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
+    };
+    if (!f._fbq) f._fbq = n;
+    n.push = n;
+    n.loaded = !0;
+    n.version = "2.0";
+    n.queue = [];
+    t = b.createElement(e);
+    t.async = !0;
+    t.src = v;
+    s = b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t, s);
+  })(
+    window,
+    document,
+    "script",
+    "https://connect.facebook.net/en_US/fbevents.js"
+  );
 
-    fbq('init', 'your-configured-pixel-id', {});
+  fbq("init", "your-configured-pixel-id", {});
 </script>
 ```
 
 This package will attempt to provide as much advanced matching data as possible by using user data from the `ConversionsApi`.
 For example when an email address is set, it will automatically be provided to the init method:
+
 ```php
 ConversionsApi::setUserData(
     (new UserData())->setEmail('john@example.com')
 );
 ```
+
 ```js
-fbq('init', 'your-configured-pixel-id', {"em": "john@example.com"});
+fbq("init", "your-configured-pixel-id", { em: "john@example.com" });
 ```
 
 Now that your Pixel is correctly initialized, it's time to send some events.
 Sadly the parameters between the Conversions API and Facebook Pixel are not identical, so they must be mapped to the [correct format](https://developers.facebook.com/docs/meta-pixel/reference).
 An easy way of doing this is by extending the `FacebookAds\Object\ServerSide\Event` class and implementing the `Esign\ConversionsApi\Contracts\MapsToFacebookPixel` interface on it:
+
 ```php
 use Esign\ConversionsApi\Contracts\MapsToFacebookPixel;
 use Esign\ConversionsApi\Facades\ConversionsApi;
@@ -212,6 +259,7 @@ class PurchaseEvent extends Event implements MapsToFacebookPixel
 ```
 
 You may now pass any class that implements the `MapsToFacebookPixel` interface to the view component responsible for tracking Facebook Pixel events:
+
 ```php
 use FacebookAds\Object\ServerSide\CustomData;
 use Illuminate\Support\Str;
@@ -226,13 +274,20 @@ $event = PurchaseEvent::create()->setCustomData(
 ```
 
 This will render the following script tag:
+
 ```html
 <script>
-    fbq('track', 'Purchase', {"currency": "EUR", "value": 10}, {"eventID": "ccf928e1-56fd-4376-bee3-dda0d7dbe136"});
+  fbq(
+    "track",
+    "Purchase",
+    { currency: "EUR", value: 10 },
+    { eventID: "ccf928e1-56fd-4376-bee3-dda0d7dbe136" }
+  );
 </script>
 ```
 
 To retrieve a list of all events that implement the `MapsToFacebookPixel` interface you may call the `filterFacebookPixelEvents` method:
+
 ```blade
 @foreach(ConversionsApi::getEvents()->filterFacebookPixelEvents() as $event)
     <x-conversions-api-facebook-pixel-tracking-event :event="$event" />
@@ -240,6 +295,7 @@ To retrieve a list of all events that implement the `MapsToFacebookPixel` interf
 ```
 
 In case you want more control over what's being rendered, you may always use the anonymous component:
+
 ```blade
 <x-conversions-api::facebook-pixel-tracking-event
     eventType="track"
@@ -250,6 +306,7 @@ In case you want more control over what's being rendered, you may always use the
 ```
 
 ### Google Tag Manager
+
 Before attempting to deduplicate events through GTM make sure to configure your GTM container id and include the necessary scripts:
 
 ```env
@@ -270,22 +327,27 @@ GOOGLE_TAG_MANAGER_ID=GTM-XXXXXX
 ```
 
 This package comes with a view component that will map all user data from the `ConversionsApi` to dataLayer variables:
+
 ```blade
 <x-conversions-api-data-layer-user-variable />
 ```
+
 For example when an email address is set, it will be automatically mapped to a dataLayer variable.
 Check the [source](src/View/Components/DataLayerUserDataVariable.php) of the view component to see a list of all possible variables.
+
 ```php
 ConversionsApi::setUserData(
     (new UserData())->setEmail('john@example.com')
 );
 ```
+
 ```js
-window.dataLayer.push({"conversionsApiUserEmail": "john@example.com"});
+window.dataLayer.push({ conversionsApiUserEmail: "john@example.com" });
 ```
 
 Now that your Pixel through GTM is correctly initialized, it's time to send some events.
 An easy way of doing this is by extending the `FacebookAds\Object\ServerSide\Event` class and implementing the `Esign\ConversionsApi\Contracts\MapsToDataLayer` interface on it:
+
 ```php
 use Esign\ConversionsApi\Contracts\MapsToDataLayer;
 use Esign\ConversionsApi\Facades\ConversionsApi;
@@ -320,6 +382,7 @@ class PurchaseEvent extends Event implements MapsToDataLayer
 ```
 
 You may now pass any class that implements the `MapsToDataLayer` interface to the view component responsible for tracking Facebook Pixel events:
+
 ```php
 use FacebookAds\Object\ServerSide\CustomData;
 use Illuminate\Support\Str;
@@ -334,18 +397,20 @@ $event = PurchaseEvent::create()->setCustomData(
 ```
 
 This will render the following script tag:
+
 ```html
 <script>
-    window.dataLayer.push({
-        "event": "conversionsApiPurchase",
-        "conversionsApiPurchaseEventId": "e2481afc-5af4-4483-bc4b-33f08e195e3a",
-        "conversionsApiPurchaseCurrency": "EUR",
-        "conversionsApiPurchaseValue": 120
-    });
+  window.dataLayer.push({
+    event: "conversionsApiPurchase",
+    conversionsApiPurchaseEventId: "e2481afc-5af4-4483-bc4b-33f08e195e3a",
+    conversionsApiPurchaseCurrency: "EUR",
+    conversionsApiPurchaseValue: 120,
+  });
 </script>
 ```
 
 To retrieve a list of all events that implement the `MapsToDataLayer` interface you may call the `filterDataLayerEvents` method:
+
 ```blade
 @foreach(ConversionsApi::getEvents()->filterDataLayerEvents() as $event)
     <x-conversions-api-data-layer-variable :event="$event" />
@@ -353,33 +418,39 @@ To retrieve a list of all events that implement the `MapsToDataLayer` interface 
 ```
 
 In case you want more control over what's being rendered, you may always use the anonymous component:
+
 ```blade
 <x-conversions-api::data-layer-variable :arguments="[]" />
 ```
 
 ## PageView Events
+
 This package ships with some helpers to track `PageView` events out of the box.
 These helpers will automatically send both Conversions API & Facebook Pixel events and provide event deduplication.
+
 > **Note**
 > Make sure to always include these view components after you've already looped over any other events currently defined on the ConversionsApi. Including these view components will clear any existing events.
 
 In case you're using the Facebook Pixel directly:
+
 ```blade
 <x-conversions-api-facebook-pixel-page-view />
 ```
+
 Or by using Google Tag Manager. The data-layer variable to deduplicate events is called `conversionsApiPageViewEventId`.
+
 ```blade
 <x-conversions-api-data-layer-page-view />
 ```
 
 ## Troubleshooting
+
 ### PageView events are not shown as deduplicated in the test events dashboard
+
 Event deduplication for PageView events should be fine out of the box, since the event name and event id parameters have been provided.
 However, when serving your application locally the ip address returned by Laravel's `request()->ip()` will be `127.0.0.1`.
 This is different from the ip address sent through Facebook Pixel, causing the Conversions API and Facebook Pixel events to not be deduplicated.
 This issue should solve itself once the application will be ran in production.
-
-
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,11 @@ composer require esign/laravel-conversions-api
 ```
 
 Next up, you can publish the configuration file:
-
 ```bash
 php artisan vendor:publish --provider="Esign\ConversionsApi\ConversionsApiServiceProvider" --tag="config"
 ```
 
 The config file will be published as config/conversions-api.php with the following content:
-
 ```php
 return [
     /**
@@ -52,10 +50,8 @@ return [
 ## Conversions API
 
 ### Events
-
 To add events to the conversions API you may use the `addEvent`, `addEvents` or `setEvents` methods.
 Retrieving or clearing events may be done using the `getEvents` and `clearEvents` methods:
-
 ```php
 use Esign\ConversionsApi\Facades\ConversionsApi;
 use FacebookAds\Object\ServerSide\UserData;
@@ -76,7 +72,6 @@ ConversionsApi::clearEvents();
 
 Adding events won't cause them to be sent to the Conversions API.
 To actually send the events you must call the `sendEvents` method:
-
 ```php
 use Esign\ConversionsApi\Facades\ConversionsApi;
 
@@ -84,7 +79,6 @@ ConversionsApi::sendEvents();
 ```
 
 #### Creating event classes
-
 To make things a bit cleaner you may extend Facebook's default event class:
 
 ```php
@@ -106,7 +100,6 @@ class PurchaseEvent extends Event
     }
 }
 ```
-
 ```php
 ConversionsApi::addEvent(
     PurchaseEvent::create()
@@ -114,7 +107,6 @@ ConversionsApi::addEvent(
 ```
 
 ### User Data
-
 This package also comes with a way to define default user data for the user of the current request.
 You may do so by calling the `setUserData` method.
 You can set the user data for every incoming request by creating a custom middleware like this one:
@@ -143,7 +135,6 @@ class InitializeFacebookUserData
 You can now use it in `App\Http\Kernel` as a global middleware or a route middleware.
 
 You may now pass the user data along with your events:
-
 ```php
 use Esign\ConversionsApi\Facades\ConversionsApi;
 use FacebookAds\Object\ServerSide\Event;
@@ -154,64 +145,41 @@ ConversionsApi::addEvent(
 ```
 
 ## Event deduplication
-
 This package comes with a few ways to assist you in [deduplicating browser and server events](https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events/). This can either be done using the Facebook Pixel directly or through Google Tag Manager's data layer.
 
 ### Facebook Pixel
-
 Before attempting to send events through Facebook Pixel make sure to load the pixel script:
-
 ```blade
 <x-conversions-api-facebook-pixel-script />
 ```
 
 This will render the following html:
-
 ```html
 <script>
-  !(function (f, b, e, v, n, t, s) {
-    if (f.fbq) return;
-    n = f.fbq = function () {
-      n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
-    };
-    if (!f._fbq) f._fbq = n;
-    n.push = n;
-    n.loaded = !0;
-    n.version = "2.0";
-    n.queue = [];
-    t = b.createElement(e);
-    t.async = !0;
-    t.src = v;
-    s = b.getElementsByTagName(e)[0];
-    s.parentNode.insertBefore(t, s);
-  })(
-    window,
-    document,
-    "script",
-    "https://connect.facebook.net/en_US/fbevents.js"
-  );
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+    document,'script','https://connect.facebook.net/en_US/fbevents.js');
 
-  fbq("init", "your-configured-pixel-id", {});
+    fbq('init', 'your-configured-pixel-id', {});
 </script>
 ```
 
 This package will attempt to provide as much advanced matching data as possible by using user data from the `ConversionsApi`.
 For example when an email address is set, it will automatically be provided to the init method:
-
 ```php
 ConversionsApi::setUserData(
     (new UserData())->setEmail('john@example.com')
 );
 ```
-
 ```js
-fbq("init", "your-configured-pixel-id", { em: "john@example.com" });
+fbq('init', 'your-configured-pixel-id', {"em": "john@example.com"});
 ```
 
 Now that your Pixel is correctly initialized, it's time to send some events.
 Sadly the parameters between the Conversions API and Facebook Pixel are not identical, so they must be mapped to the [correct format](https://developers.facebook.com/docs/meta-pixel/reference).
 An easy way of doing this is by extending the `FacebookAds\Object\ServerSide\Event` class and implementing the `Esign\ConversionsApi\Contracts\MapsToFacebookPixel` interface on it:
-
 ```php
 use Esign\ConversionsApi\Contracts\MapsToFacebookPixel;
 use Esign\ConversionsApi\Facades\ConversionsApi;
@@ -259,7 +227,6 @@ class PurchaseEvent extends Event implements MapsToFacebookPixel
 ```
 
 You may now pass any class that implements the `MapsToFacebookPixel` interface to the view component responsible for tracking Facebook Pixel events:
-
 ```php
 use FacebookAds\Object\ServerSide\CustomData;
 use Illuminate\Support\Str;
@@ -274,20 +241,13 @@ $event = PurchaseEvent::create()->setCustomData(
 ```
 
 This will render the following script tag:
-
 ```html
 <script>
-  fbq(
-    "track",
-    "Purchase",
-    { currency: "EUR", value: 10 },
-    { eventID: "ccf928e1-56fd-4376-bee3-dda0d7dbe136" }
-  );
+    fbq('track', 'Purchase', {"currency": "EUR", "value": 10}, {"eventID": "ccf928e1-56fd-4376-bee3-dda0d7dbe136"});
 </script>
 ```
 
 To retrieve a list of all events that implement the `MapsToFacebookPixel` interface you may call the `filterFacebookPixelEvents` method:
-
 ```blade
 @foreach(ConversionsApi::getEvents()->filterFacebookPixelEvents() as $event)
     <x-conversions-api-facebook-pixel-tracking-event :event="$event" />
@@ -295,7 +255,6 @@ To retrieve a list of all events that implement the `MapsToFacebookPixel` interf
 ```
 
 In case you want more control over what's being rendered, you may always use the anonymous component:
-
 ```blade
 <x-conversions-api::facebook-pixel-tracking-event
     eventType="track"
@@ -306,7 +265,6 @@ In case you want more control over what's being rendered, you may always use the
 ```
 
 ### Google Tag Manager
-
 Before attempting to deduplicate events through GTM make sure to configure your GTM container id and include the necessary scripts:
 
 ```env
@@ -327,27 +285,22 @@ GOOGLE_TAG_MANAGER_ID=GTM-XXXXXX
 ```
 
 This package comes with a view component that will map all user data from the `ConversionsApi` to dataLayer variables:
-
 ```blade
 <x-conversions-api-data-layer-user-variable />
 ```
-
 For example when an email address is set, it will be automatically mapped to a dataLayer variable.
 Check the [source](src/View/Components/DataLayerUserDataVariable.php) of the view component to see a list of all possible variables.
-
 ```php
 ConversionsApi::setUserData(
     (new UserData())->setEmail('john@example.com')
 );
 ```
-
 ```js
-window.dataLayer.push({ conversionsApiUserEmail: "john@example.com" });
+window.dataLayer.push({"conversionsApiUserEmail": "john@example.com"});
 ```
 
 Now that your Pixel through GTM is correctly initialized, it's time to send some events.
 An easy way of doing this is by extending the `FacebookAds\Object\ServerSide\Event` class and implementing the `Esign\ConversionsApi\Contracts\MapsToDataLayer` interface on it:
-
 ```php
 use Esign\ConversionsApi\Contracts\MapsToDataLayer;
 use Esign\ConversionsApi\Facades\ConversionsApi;
@@ -382,7 +335,6 @@ class PurchaseEvent extends Event implements MapsToDataLayer
 ```
 
 You may now pass any class that implements the `MapsToDataLayer` interface to the view component responsible for tracking Facebook Pixel events:
-
 ```php
 use FacebookAds\Object\ServerSide\CustomData;
 use Illuminate\Support\Str;
@@ -397,20 +349,18 @@ $event = PurchaseEvent::create()->setCustomData(
 ```
 
 This will render the following script tag:
-
 ```html
 <script>
-  window.dataLayer.push({
-    event: "conversionsApiPurchase",
-    conversionsApiPurchaseEventId: "e2481afc-5af4-4483-bc4b-33f08e195e3a",
-    conversionsApiPurchaseCurrency: "EUR",
-    conversionsApiPurchaseValue: 120,
-  });
+    window.dataLayer.push({
+        "event": "conversionsApiPurchase",
+        "conversionsApiPurchaseEventId": "e2481afc-5af4-4483-bc4b-33f08e195e3a",
+        "conversionsApiPurchaseCurrency": "EUR",
+        "conversionsApiPurchaseValue": 120
+    });
 </script>
 ```
 
 To retrieve a list of all events that implement the `MapsToDataLayer` interface you may call the `filterDataLayerEvents` method:
-
 ```blade
 @foreach(ConversionsApi::getEvents()->filterDataLayerEvents() as $event)
     <x-conversions-api-data-layer-variable :event="$event" />
@@ -418,39 +368,33 @@ To retrieve a list of all events that implement the `MapsToDataLayer` interface 
 ```
 
 In case you want more control over what's being rendered, you may always use the anonymous component:
-
 ```blade
 <x-conversions-api::data-layer-variable :arguments="[]" />
 ```
 
 ## PageView Events
-
 This package ships with some helpers to track `PageView` events out of the box.
 These helpers will automatically send both Conversions API & Facebook Pixel events and provide event deduplication.
-
 > **Note**
 > Make sure to always include these view components after you've already looped over any other events currently defined on the ConversionsApi. Including these view components will clear any existing events.
 
 In case you're using the Facebook Pixel directly:
-
 ```blade
 <x-conversions-api-facebook-pixel-page-view />
 ```
-
 Or by using Google Tag Manager. The data-layer variable to deduplicate events is called `conversionsApiPageViewEventId`.
-
 ```blade
 <x-conversions-api-data-layer-page-view />
 ```
 
 ## Troubleshooting
-
 ### PageView events are not shown as deduplicated in the test events dashboard
-
 Event deduplication for PageView events should be fine out of the box, since the event name and event id parameters have been provided.
 However, when serving your application locally the ip address returned by Laravel's `request()->ip()` will be `127.0.0.1`.
 This is different from the ip address sent through Facebook Pixel, causing the Conversions API and Facebook Pixel events to not be deduplicated.
 This issue should solve itself once the application will be ran in production.
+
+
 
 ## Testing
 


### PR DESCRIPTION
## Omschrijving

The readme stated to add `ConversionsApi::setUserData` in `AppServiceProvider` boot method but it actually do nothing because the session in not yet initialized in `AppServiceProvider`, so `auth()->user()` will always be null.

I suggest to put `ConversionsApi::setUserData` in a middleware.

## Type aanpassing

- Documentation update

## Testen

No test changed or new test needed.

## Checklist:

Vervolledig de checklist & verwijder opties die niet relevant zijn.

- [x] Mijn code voldoet aan de briefing
- [x] Ik heb mijn code gecontroleerd en eventuele spelfouten gecorrigeerd
- [x] Ik heb commentaar geplaatst waar nodig, vooral op moeilijk te begrijpen plaatsen
- [x] Ik heb de wijzigingen in de documentatie toegevoegd
- [x] Mijn wijzigingen genereren geen nieuwe lintfouten en waarschuwingen
- [x] Ik heb het resultaat in verschillende browsers & responsief getest
- [x] Ik heb de wijzigingen volledig getest op mobiel
- [x] Vertalen is mogelijk
