### PR TITLE
Support facebook pixel consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ ConversionsApi::setUserData(
 fbq('init', 'your-configured-pixel-id', {"em": "john@example.com"});
 ```
 #### Manage cookie consent and GDPR compliance
-The Facebook pixel offer a way to revoke and grant consent to make your app GDPR compliante.
+The Facebook pixel offer a way to revoke and grant consent to make your app GDPR compliant.
 
 You can pass the `revoke` attribute to the blade component to revoke consent.
 Usually the user consent is stored in another Cookie, so a standard workflow would look like that:

--- a/README.md
+++ b/README.md
@@ -176,6 +176,40 @@ ConversionsApi::setUserData(
 ```js
 fbq('init', 'your-configured-pixel-id', {"em": "john@example.com"});
 ```
+#### Manage cookie consent and GDPR compliance
+The Facebook pixel offer a way to revoke and grant consent to make your app GDPR compliante.
+
+You can pass the `revoke` attribute to the blade component to revoke consent.
+Usually the user consent is stored in another Cookie, so a standard workflow would look like that:
+```blade
+<x-conversions-api-facebook-pixel-script revoke="Cookie::get('consent_facebook', false)" />
+```
+
+It will render the following html:
+```html
+<script>
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+    document,'script','https://connect.facebook.net/en_US/fbevents.js');
+
+    fbq('consent', 'revoke');
+    fbq('init', 'your-configured-pixel-id', {});
+</script>
+```
+
+Once you explicitly get the consent of the user with your own method, you should call:
+```html
+<script>
+    fbq('consent', 'grant');
+</script>
+```
+The Facebook Pixel will start sending events as usual. 
+You can learn more about it here: https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/#cookieconsent
+
+
+#### Sending Events with the pixel
 
 Now that your Pixel is correctly initialized, it's time to send some events.
 Sadly the parameters between the Conversions API and Facebook Pixel are not identical, so they must be mapped to the [correct format](https://developers.facebook.com/docs/meta-pixel/reference).

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The Facebook pixel offer a way to revoke and grant consent to make your app GDPR
 You can pass the `revoke` attribute to the blade component to revoke consent.
 Usually the user consent is stored in another Cookie, so a standard workflow would look like that:
 ```blade
-<x-conversions-api-facebook-pixel-script revoke="Cookie::get('consent_facebook', false)" />
+<x-conversions-api-facebook-pixel-script revoke="!Cookie::get('consent_facebook', false)" />
 ```
 
 It will render the following html:

--- a/resources/views/components/facebook-pixel-script.blade.php
+++ b/resources/views/components/facebook-pixel-script.blade.php
@@ -5,5 +5,9 @@
     t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
     document,'script','https://connect.facebook.net/en_US/fbevents.js');
 
+    @if ($revoke)
+        fbq('consent', 'revoke');
+    @endif
+
     fbq('init', '{{ $pixelId }}', @json((object) $advancedMatchingData));
 </script>

--- a/src/View/Components/FacebookPixelScript.php
+++ b/src/View/Components/FacebookPixelScript.php
@@ -9,6 +9,11 @@ class FacebookPixelScript extends Component
 {
     protected ?string $pixelId;
     protected array $advancedMatchingData;
+    /**
+     * Manage GDPR consent by revoking consent before pixel init
+     * @see https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/#cookieconsent
+     */
+    protected ?bool $revoke;
 
     /**
      * @param null|string $pixelId
@@ -17,10 +22,12 @@ class FacebookPixelScript extends Component
      */
     public function __construct(
         ?string $pixelId = null,
-        ?array $advancedMatchingData = null
+        ?array $advancedMatchingData = null,
+        ?bool $revoke = false,
     ) {
         $this->pixelId = $pixelId ?? config('conversions-api.pixel_id');
         $this->advancedMatchingData = $advancedMatchingData ?? $this->getAdvancedMatchingDataFromConversionsApiUserData();
+        $this->revoke = $revoke;
     }
 
     protected function getAdvancedMatchingDataFromConversionsApiUserData(): array
@@ -47,6 +54,7 @@ class FacebookPixelScript extends Component
         return view('conversions-api::components.facebook-pixel-script', [
             'pixelId' => $this->pixelId,
             'advancedMatchingData' => $this->advancedMatchingData,
+            'revoke' => $this->revoke,
         ]);
     }
 }

--- a/tests/Feature/View/Components/FacebookPixelScriptTest.php
+++ b/tests/Feature/View/Components/FacebookPixelScriptTest.php
@@ -21,6 +21,7 @@ class FacebookPixelScriptTest extends TestCase
         $component = $this->component(FacebookPixelScript::class);
 
         $component->assertSee("fbq('init', '414800860114807', {\"em\":\"test@test.com\"});", false);
+        $component->assertDontSee("fbq('consent', 'revoke');", true);
     }
 
     /** @test */
@@ -41,5 +42,27 @@ class FacebookPixelScriptTest extends TestCase
         ]);
 
         $component->assertSee("fbq('init', '744689831385767', {\"em\":\"test@test.com\"});", false);
+    }
+
+    /** @test */
+    public function it_can_render_the_view_with_revoking_consent()
+    {
+        $component = $this->component(FacebookPixelScript::class, [
+            'pixelId' => '744689831385767',
+            'revoke' => true,
+        ]);
+
+        $component->assertSee("fbq('consent', 'revoke');", false);
+    }
+
+    /** @test */
+    public function it_can_render_the_view_without_revoking_consent()
+    {
+        $component = $this->component(FacebookPixelScript::class, [
+            'pixelId' => '744689831385767',
+            'revoke' => false,
+        ]);
+
+        $component->assertDontSee("fbq('consent', 'revoke');", true);
     }
 }


### PR DESCRIPTION
## Omschrijving

This PR add the possibility to manage GDPR user consent by revoking consent before calling `fb('init', ...)` when using the blade component.
The procedure implemented is described here: https://developers.facebook.com/docs/meta-pixel/implementation/gdpr/#cookieconsent

## Type aanpassing

Verwijder opties die niet relevant zijn.

- New feature ✅
- Deze wijziging vereist een documentatie update ✅

## Testen

The blade component is now tested against the presence of `fbq('consent', 'revoke');`

## Checklist:

Vervolledig de checklist & verwijder opties die niet relevant zijn.

- [x] Mijn code voldoet aan de briefing
- [x] Ik heb mijn code gecontroleerd en eventuele spelfouten gecorrigeerd
- [x] Ik heb commentaar geplaatst waar nodig, vooral op moeilijk te begrijpen plaatsen
- [x] Ik heb de wijzigingen in de documentatie toegevoegd
- [x] Mijn wijzigingen genereren geen nieuwe lintfouten en waarschuwingen
- [x] Ik heb het resultaat in verschillende browsers & responsief getest
- [x] Ik heb de wijzigingen volledig getest op mobiel
- [x] Vertalen is mogelijk
