### PR TITLE
bump facebook sdk to v23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "facebook/php-business-sdk": "^19.0",
+        "facebook/php-business-sdk": "^23.0",
         "illuminate/http": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0"
     },

--- a/src/ConversionsApi.php
+++ b/src/ConversionsApi.php
@@ -68,7 +68,7 @@ class ConversionsApi
     public function sendEvents(): PromiseInterface
     {
         $eventRequest = (new EventRequestAsync(config('conversions-api.pixel_id')))
-            ->setEvents($this->events);
+            ->setEvents($this->events->all());
 
         if ($testCode = config('conversions-api.test_code')) {
             $eventRequest->setTestEventCode($testCode);


### PR DESCRIPTION
## Description
bump facebook sdk to v23. This also fix some deprecation warning with php 8.4 (fixed in newer facebook sdk)

## How has this been tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

